### PR TITLE
Set box name

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -8,13 +8,15 @@ Vagrant.configure(2) do |config|
   config.landrush.host 'elastic.dev', VM_IP
   config.landrush.tld = 'dev'
 
-  config.vm.box = "puphpet/ubuntu1404-x64"
-  config.vm.hostname = "elasticsearch.dev"
-  config.vm.network "private_network", ip: VM_IP
-
   config.ssh.forward_agent = true
 
-  config.vm.synced_folder "..", "/vagrant", type: 'nfs'
+  config.vm.synced_folder "..", "/vagrant"
+
+  config.vm.define "elasticsearch-ubuntu" do |box|
+    box.vm.box = "puphpet/ubuntu1404-x64"
+    box.vm.hostname = "elastic.dev"
+    box.vm.network "private_network", ip: VM_IP
+  end
 
   config.vm.provision :puppet do |puppet|
     puppet.module_path       = ["modules", "custom_modules"]

--- a/vagrant/env/development/manifests/site.pp
+++ b/vagrant/env/development/manifests/site.pp
@@ -26,7 +26,8 @@ class { "elasticsearch":
     "path.conf"                   => "/etc/elasticsearch",
     "path.data"                   => "/var/lib/elasticsearch",
     "gateway.expected_nodes"      => 1,
-    "gateway.recover_after_nodes" => 1
+    "gateway.recover_after_nodes" => 1,
+    "network.host"                => "0.0.0.0"
   }
 }
 


### PR DESCRIPTION
This PR sets the box name of the VM from `default` to `elasticsearch-ubuntu`. It also runs ES on network interface `0.0.0.0` to allow access from outside the VM (kopf plugin).