### PR TITLE
Clarify and extend setup steps in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ ELK stack VM with Vagrant and Puppet including the Movies100k rating dataset by 
 You need the following tools:
 
 - Ruby 2.x
-- Vagrant 1.8.x
+- Vagrant 1.8.6
+- VirtualBox 5.1.6
 - bundler
 
 ## Setup
@@ -32,9 +33,10 @@ $ vagrant plugin install vagrant-vbguest  # only with Virtualbox
 To install all gems and set up Puppet run:
 
 ```
+$ cd vagrant
 $ bundle install
 $ librarian-puppet install
-$ vagrant up
+$ vagrant up --provider virtualbox
 ```
 
 After provisioning succeeds log into the box
@@ -42,6 +44,10 @@ After provisioning succeeds log into the box
 ```
 $ vagrant ssh
 ```
+
+### Kopf
+
+The [kopf plugin](https://github.com/lmenezes/elasticsearch-kopf) offers a web interface to the Elasticsearch cluster and is available at [http://elastic.dev:9200/\_plugin/kopf/](http://elastic.dev:9200/_plugin/kopf/#!/cluster) and via the IP of the VM, [http://172.17.1.22:9200/\_plugin/kopf/](http://172.17.1.22:9200/_plugin/kopf). The former URL is available via the landrush vagrant plugin.
 
 
 ### Kibana

--- a/dataset/movies-100k/Readme.md
+++ b/dataset/movies-100k/Readme.md
@@ -4,19 +4,27 @@ Movielens Dataset
 This folder contains scripts and tasks to import the [movies-100k](http://grouplens.org/datasets/movielens/) dataset that contains 100.000 ratings from nearly 1.000 users for about 1.700 different movies, all part of the [Movielens.org](http://movielens.org) website.
 It also allows to download and import the [movies-1M](http://grouplens.org/datasets/movielens/) dataset with 1 million ratings from 6.000 users on 4.000 movies.
 
-The repository should be available at `/vagrant` inside the VM. Log into the VM, change to the folder and set up the project with bundler:
+The repository should be available at `/vagrant` inside the VM. First connect into the VM and set up the data set.
+
+To connect into the VM run:
 
 ```bash
 $ vagrant ssh
+```
+
+The following commands are run inside the VM.
+
+```
 $ cd /vagrant/dataset/movies-100k
 $ gem install bundler
 $ bundle install
 ```
 
-The project folder also contains a Rakefile in the folder `/vagrant/dataset/movies-100k`. Change directory and then run rake to list all available tasks:
+First bundler is installed, then all required gem dependencies.
+
+Inside the folder `dataset/movies-100k` there is a Rakefile that provides a number of tasks. To display a list of all available rake tasks run:
 
 ```bash
-$ cd /vagrant/dataset/movies-100k
 $ bundle exec rake -T
 ```
 

--- a/dataset/movies-100k/Readme.md
+++ b/dataset/movies-100k/Readme.md
@@ -4,17 +4,19 @@ Movielens Dataset
 This folder contains scripts and tasks to import the [movies-100k](http://grouplens.org/datasets/movielens/) dataset that contains 100.000 ratings from nearly 1.000 users for about 1.700 different movies, all part of the [Movielens.org](http://movielens.org) website.
 It also allows to download and import the [movies-1M](http://grouplens.org/datasets/movielens/) dataset with 1 million ratings from 6.000 users on 4.000 movies.
 
-
-The repository should be available at `/vagrant` inside the VM. Change directory and to set up the project run:
+The repository should be available at `/vagrant` inside the VM. Log into the VM, change to the folder and set up the project with bundler:
 
 ```bash
+$ vagrant ssh
 $ cd /vagrant/dataset/movies-100k
+$ gem install bundler
 $ bundle install
 ```
 
-This project folder also contains a Rakefile, to see all available rake tasks run:
+The project folder also contains a Rakefile in the folder `/vagrant/dataset/movies-100k`. Change directory and then run rake to list all available tasks:
 
 ```bash
+$ cd /vagrant/dataset/movies-100k
 $ bundle exec rake -T
 ```
 


### PR DESCRIPTION
Add and fix setup information in Readme files.

* set specific versions for vagrant + virtualbox
* fix set up steps by adding more instructions
* add section on kopf plugin and links to plugin site